### PR TITLE
Do not update last_event_time upon receiving a challenge

### DIFF
--- a/game_manager.py
+++ b/game_manager.py
@@ -100,7 +100,6 @@ class GameManager:
             await self.li.accept_challenge(self.challenge_queue.popleft())
 
     async def on_challenge(self, event: dict) -> None:
-        self.last_event_time = time.monotonic()
         challenge_id = event["challenge"]["id"]
 
         if challenge_id in self.challenge_queue:


### PR DESCRIPTION
the problem is that we may not accept the challenge, but reseting will prevent us from sending challenges.

extreme example: setup bot to refuse bot challenges, but send a challenge every hour. the bot will never be able to send any challenge, because it will be spammed constantly by bot challenges (refused) that reset this last_event_time.