### PR TITLE
Improve matchmaking hit ratio

### DIFF
--- a/config.default.yml
+++ b/config.default.yml
@@ -80,6 +80,6 @@ matchmaking:
     - 0
     - 1
   max_rating_diff: 4000       # Maximum rating distance to opponent.
-  min_games: 250              # Minimum games opponent must have played.
+  min_games: 50               # Minimum games opponent must have played in the chosen variant (including sub-division of standard into bullet, blitz etc.)
   timeout: 5                  # Timeout (in minutes) between nothing happening and issuing a challenge.
   rated: false                # Whether to challenge rated or casual.

--- a/matchmaker.py
+++ b/matchmaker.py
@@ -26,9 +26,6 @@ class Bot:
         return NotImplemented
 
     @property
-    def total_games(self) -> int:
-        return sum(self._num_games.values())
-
     def num_games(self, perf_type) -> int:
         return self._num_games[perf_type]
 
@@ -44,7 +41,7 @@ class Bot:
         ):
             return False
 
-        if other.total_games < CONFIG["matchmaking"]["min_games"]:
+        if other.num_games(perf_type) < CONFIG["matchmaking"]["min_games"]:
             return False
 
         return True

--- a/matchmaker.py
+++ b/matchmaker.py
@@ -25,7 +25,6 @@ class Bot:
             return self.name == other.name
         return NotImplemented
 
-    @property
     def num_games(self, perf_type) -> int:
         return self._num_games[perf_type]
 


### PR DESCRIPTION
Most bots refuse variants, even chess960 is rarely accepted.

Even for standard chess, most refuse Classical. And many even refuse Rapid.

So we must make this min_games more granular, to avoid wasting challenges that will almost surely be declined.

I am getting this syntax error, that I can't make sense of:
```
if other.num_games(perf_type) < CONFIG["matchmaking"]["min_games"]:
^^^^^^^^^^^^^^^
TypeError: Bot.num_games() missing 1 required positional argument: 'perf_type'
```
Sending the pull request nonetheless, so you see the problem I am trying to solve.