### PR TITLE
Revert "use .env for token"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.yml
+!config.default.yml
+!docker-compose.yml

--- a/config.default.yml
+++ b/config.default.yml
@@ -1,3 +1,4 @@
+token: "XXXXXXXXXXXXXXX"
 concurrency: 1                # Number of games to play simultaneously.
 abort_time: 20                # Amount of time (in s) to abort game start after no activity.
 move_overhead : 2000          # Amount of time (in ms) to subtract from each move before being given to the engine.

--- a/config.py
+++ b/config.py
@@ -15,7 +15,8 @@ def load_config(filename: str):
         except Exception as e:
             logger.critical("There is a problem with your config.yml file.")
             raise e
-    config["token"] = os.getenv("LICHESS_TOKEN")
+    if "LICHESS_BOT_TOKEN" in os.environ:
+        config["token"] = os.environ["LICHESS_BOT_TOKEN"]
 
     global CONFIG
     CONFIG.clear()

--- a/main.py
+++ b/main.py
@@ -4,13 +4,10 @@ import asyncio
 import logging
 
 import httpx
-from dotenv import load_dotenv
 
 import config
 from game_manager import GameManager
 from lichess import Lichess
-
-load_dotenv()
 
 LOGO = r"""
                               __ _             _           _

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 httpx ~= 0.28.1
 chess ~= 1.11.2
 PyYAML ~= 6.0
-python-dotenv==1.1.1


### PR DESCRIPTION
Relying on an environment variable for the token is impractical, especially when using multiple bots.

Usage since ".env for token":
```
LICHESS_TOKEN=lip_*** main.py -c bot1.yml &> bot1.log
& LICHESS_TOKEN=lip_*** main.py -c bot2.yml &> bot2.log &
```
Previously:
```
main.py -c bot1.yml &> bot1.log &
main.py -c bot2.yml &> bot2.log &
```
Also we remove a dependancy on `python-dotenv`.

The only reason I can see for moving the token outside config.yml and into a `.env` is to prevent accidental commits of `config.yml` files, leaking the token through github.

But we need a `.gitignore` with `*.env` to ensure that, which we don't have. So, I'm enforcing the intended same safety feature, with `.gitignore` for `*.yml` files, excluding `config.default.yml` and `docker-compose.yml`.